### PR TITLE
docs(readme): improve documentation and configuration

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 node_modules
 CHANGELOG.md
+LICENSE

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,5 +1,5 @@
 /**
- * @see https://prettier.io/docs/en/configuration.html
+ * @see https://prettier.io/docs/configuration
  * @type {import("prettier").Config}
  */
 module.exports = {

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 X-Squared on Demand
+Copyright (c) 2026 X-Squared on Demand
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # `@x2od/prettier-config`
 
-> A shared [Prettier](https://prettier.io) config for X-Squared on Demand.
+> A shared [Prettier](https://prettier.io) config for [X-Squared on Demand](https://www.x2od.com).
 
 ## Installation
 
-To install this package run the following command in the terminal in the root directory of your application.
+To install this package, run the following command in the terminal in the root directory of your application.
 
 ```bash
 npm install --save-dev @x2od/prettier-config
@@ -16,21 +16,21 @@ Reference it in `package.json` using the `prettier` property:
 
 ```json
 {
-  "name": "my-projects-name",
-  "prettier": "@x2od/prettier-config",
-  "devDependencies": {
-    "@x2od/prettier-config": "latest"
-  }
+	"name": "my-projects-name",
+	"prettier": "@x2od/prettier-config",
+	"devDependencies": {
+		"@x2od/prettier-config": "latest"
+	}
 }
 ```
 
 **OR**
 
-If you don't want to use `package.json`, you can use any of the supported
+If you don't want to use `package.json`, you can use any of the supported config file
 extensions to export a string:
 
 ```jsonc
-// `.prettierrc.json` or `.prettierrc` or `.prettierrc.yaml` or `.prettierrc.yml` or `prettierrc.json`
+// `.prettierrc.json` or `.prettierrc` or `.prettierrc.yaml` or `.prettierrc.yml` or `.prettierrc.json`
 "@x2od/prettier-config"
 ```
 
@@ -45,9 +45,10 @@ To use the configuration as written:
 module.exports = '@x2od/prettier-config';
 ```
 
-To *extend* the configuration to overwrite some properties from the shared configuration, import the file in a `prettier.config.mjs` file and export the modifications, e.g:
+To _extend_ and override properties from the shared configuration, import the file in a `prettier.config.mjs` file and export the modifications, e.g:
+
 <!-- prettier-ignore -->
-```js
+```javascript
 // prettier.config.mjs
 import x2odPrettierConfig from "@x2od/prettier-config";
 
@@ -63,11 +64,23 @@ const config = {
 export default config;
 ```
 
+**CommonJS note:** ES module syntax requires a `.mjs` file. For `.js` files, use `require()` instead:
+
+```js
+// `prettier.config.js` or `.prettierrc.js`
+const x2odPrettierConfig = require('@x2od/prettier-config');
+
+module.exports = {
+	...x2odPrettierConfig,
+	semi: true
+};
+```
+
 ### Extending Shared Configurations
 
-This configuration is not intended to be changed, but if you have a setup where
-modification is required, it is possible. Prettier does not offer an "extends"
-mechanism as you might be familiar from tools such as ESLint.
+While this configuration is designed to be used as-is, you can extend it if your
+project requires custom overrides. Prettier does not offer an "extends" mechanism
+as you might be familiar from tools such as ESLint.
 
 To extend a configuration you will need to:
 
@@ -78,67 +91,117 @@ Prettier uses [cosmiconfig](https://github.com/davidtheclark/cosmiconfig) for
 configuration file support. This means you can configure prettier via:
 
 - A `.prettierrc` file, written in YAML or JSON, with optional extensions: `.yaml/.yml/.json`.
-- A `prettier.config.js` or `.prettierrc.js` file that exports an object.
+- A `prettier.config.js`, `.prettierrc.js`,`prettier.config.mjs`, or `.prettierrc.mjs` file that exports an object.
 - A `"prettier"` key in your `package.json` file.
 
-**Sharing configurations**
->
-> Note: This method does **not** offer a way to _extend_ the configuration to overwrite some properties from the shared configuration. If you need to do that, import the file in a `.prettierrc.js` file and export the modifications, e.g:
->
-> ```js
-> import x2odPrettierConfig from '@x2od/prettier-config';
->
-> export default {
->  ...x2odPrettierConfig,
->  semi: false
-> };
-> ```
->
-> _source: <https://github.com/prettier/prettier/blob/main/docs/configuration.md>_
-
-**NOTE: THE ABOVE DOES NOT WORK! You will get an error that you cannot use import outside of a module. Please use the below instead.**
-
-For example, if you need to change it so that semicolons are required:
+For example, if you need to add overrides for `.js`:
 
 ```javascript
 // `prettier.config.js` or `.prettierrc.js`
 const x2odPrettierConfig = require('@x2od/prettier-config');
 
 module.exports = {
-  ...x2odPrettierConfig,
-  semi: true
+	...x2odPrettierConfig,
+	semi: true
 };
 ```
 
 ### Configuration Considerations
 
-WHen extending, in the `js` configuration file, do not use an array for files. You must use a single string, but can put alternate values in curly braces:
+When extending, in the `js` configuration file, do not use an array for files. Prettier's override syntax requires a single string pattern (not arrays). Use curly braces for alternation:
 
-```javascript
+```json
 {
-  files: '*.{yaml,yml}', // ['*.yaml','*.yml'] does not work
-  options: {
-    singleQuote: true
-  }
+	"files": "*.{yaml,yml}", // ['*.yaml','*.yml'] does not work
+	"options": {
+		"singleQuote": true
+	}
 }
 ```
 
-To extend any section of the original file, refer to the original configuration and its attribute:
+To extend any section of the original file, refer to the original configuration and its attribute. This includes adding plugins. Be sure to include those additional plugins as local devDependencies.
 
 ```javascript
+// prettier.config.js CommonJS
+/* eslint-disable no-undef */
+const x2odPrettierConfig = require('@x2od/prettier-config');
+
+/**
+ * @see https://prettier.io/docs/configuration
+ * @type {import("prettier").Config}
+ */
 module.exports = {
-  //...require('@x2od/prettier-config'),
-  ...x2odPrettierConfig,
-  $schema: 'https://json.schemastore.org/prettierrc',
-  overrides: [
-    ...x2odPrettierConfig.overrides,
-    {
-      files: '*.sh',
-      options: {
-        parser: 'sh'
-      }
-    }
-  ],
-  plugins: [...x2odPrettierConfig.plugins, 'prettier-plugin-sh']
+	...x2odPrettierConfig,
+	tabWidth: 2,
+	overrides: [
+		...x2odPrettierConfig.overrides,
+		{
+			files: '*.sh',
+			options: {
+				parser: 'sh',
+				useTabs: false
+			}
+		}
+	],
+	plugins: [...x2odPrettierConfig.plugins, 'prettier-plugin-sh']
 };
+```
+
+or to put the require line in the exports block. Note that arrays do not need to be extended if `require` is in teh exports block.
+
+```javascript
+/**
+ * @see https://prettier.io/docs/configuration
+ * @type {import("prettier").Config}
+ */
+module.exports = {
+	...require('@x2od/prettier-config'),
+	$schema: 'https://json.schemastore.org/prettierrc',
+	overrides: [
+		{
+			files: 'index.json',
+			options: {
+				singleQuote: false,
+				printWidth: 80
+			}
+		},
+		{
+			files: '.prettierrc.js',
+			options: {
+				singleQuote: true
+			}
+		}
+	]
+};
+```
+
+We can do the same for `.mjs` files
+
+```javascript
+// .prettierrc.mjs or prettier.config.mjs ESM
+import x2odPrettierConfig from '@x2od/prettier-config' with { type: 'json' };
+// The json type specification is because this package has a JSON configuration file.
+// If your package exports javascript, you will not need this.
+
+/**
+ * @see https://prettier.io/docs/configuration
+ * @type {import("prettier").Config}
+ */
+const config = {
+	...x2odPrettierConfig,
+	$schema: 'https://json.schemastore.org/prettierrc',
+	printWidth: 180,
+	overrides: [
+		...x2odPrettierConfig.overrides,
+		{
+			files: '*.sh',
+			options: {
+				parser: 'sh'
+			}
+		}
+	],
+	plugins: [...x2odPrettierConfig.plugins, 'prettier-plugin-sh']
+};
+
+export default config;
 ```

--- a/README.md
+++ b/README.md
@@ -4,88 +4,76 @@
 
 ## Installation
 
-To install this package, run the following command in the terminal in the root directory of your application.
-
 ```bash
 npm install --save-dev @x2od/prettier-config
 ```
 
-## Usage
+## Basic Usage
 
-Reference it in `package.json` using the `prettier` property:
+Prettier supports multiple ways to reference this config in a project. Choose one:
+
+**Via `package.json`:**
 
 ```json
 {
-	"name": "my-projects-name",
-	"prettier": "@x2od/prettier-config",
-	"devDependencies": {
-		"@x2od/prettier-config": "latest"
-	}
+	"prettier": "@x2od/prettier-config"
 }
 ```
 
-**OR**
+**Via `.prettierrc` (JSON or YAML):**
 
-If you don't want to use `package.json`, you can use any of the supported config file
-extensions to export a string:
-
-```jsonc
-// `.prettierrc.json` or `.prettierrc` or `.prettierrc.yaml` or `.prettierrc.yml` or `.prettierrc.json`
+```json
 "@x2od/prettier-config"
 ```
 
-**OR**
-
-Create a `prettier.config.js` or `.prettierrc.js` file and export an object.
-
-To use the configuration as written:
+**Via `prettier.config.js` or `.prettierrc.js`:**
 
 ```js
-// `prettier.config.js` or `.prettierrc.js`
 module.exports = '@x2od/prettier-config';
 ```
 
-To _extend_ and override properties from the shared configuration, import the file in a `prettier.config.mjs` file and export the modifications, e.g:
-
-<!-- prettier-ignore -->
-```javascript
-// prettier.config.mjs
-import x2odPrettierConfig from "@x2od/prettier-config";
-
-/**
- * @see https://prettier.io/docs/configuration
- * @type {import("prettier").Config}
- */
-const config = {
-  ...x2odPrettierConfig,
-  semi: false,
-};
-
-export default config;
-```
-
-**CommonJS note:** ES module syntax requires a `.mjs` file. For `.js` files, use `require()` instead:
+**Via `prettier.config.mjs`, or `.prettierrc.mjs`:**
 
 ```js
-// `prettier.config.js` or `.prettierrc.js`
-const x2odPrettierConfig = require('@x2od/prettier-config');
-
-module.exports = {
-	...x2odPrettierConfig,
-	semi: true
-};
+import x2odPrettierConfig from '@x2od/prettier-config';
+export default x2odPrettierConfig;
 ```
 
-### Extending Shared Configurations
+## Default Configuration
 
-While this configuration is designed to be used as-is, you can extend it if your
-project requires custom overrides. Prettier does not offer an "extends" mechanism
-as you might be familiar from tools such as ESLint.
+This config includes sensible defaults optimized for Salesforce development and general web projects:
 
-To extend a configuration you will need to:
+**Base settings:**
 
-1.  Import/Require this sharable config from within your own configuration. This means you must be using a JavaScript version of a Prettier configuration file.
-1.  Export the modified configuration
+- **printWidth**: 180
+- **tabWidth**: 2
+- **useTabs**: true
+- **singleQuote**: true
+- **trailingComma**: "none"
+- **bracketSpacing**: true
+- **bracketSameLine**: true
+- **endOfLine**: "lf"
+
+**File-specific overrides** are included for:
+
+- `.{cmp,page,component}` — Salesforce Lightning components
+- `.{cls,trigger}` — Apex classes and triggers
+- `.{apex,soql}` — Apex anonymous and SOQL
+- `*.xml` — XML with custom attribute grouping
+- `.{yml,yaml}` — YAML files
+- `*.json` — JSON files (printWidth: 80)
+- `.prettierrc*` — Prettier config files (printWidth: 80)
+- `.html` — HTML files with custom attribute grouping
+
+**Plugins:**
+
+- `prettier-plugin-apex` — Apex language support
+- `@prettier/plugin-xml` — XML formatting
+- `prettier-plugin-organize-attributes` — HTML attribute organization
+
+## Extending Shared Configurations
+
+While this configuration is designed to be used as-is, you can extend it if your project requires custom overrides. Prettier does not offer an "extends" mechanism like ESLint.
 
 Prettier uses [cosmiconfig](https://github.com/davidtheclark/cosmiconfig) for
 configuration file support. This means you can configure prettier via:
@@ -94,36 +82,12 @@ configuration file support. This means you can configure prettier via:
 - A `prettier.config.js`, `.prettierrc.js`,`prettier.config.mjs`, or `.prettierrc.mjs` file that exports an object.
 - A `"prettier"` key in your `package.json` file.
 
-For example, if you need to add overrides for `.js`:
+To extend the configuration, import/require it in a JavaScript config file and export your modifications:
+
+**With CommonJS (`.js`):**
 
 ```javascript
-// `prettier.config.js` or `.prettierrc.js`
-const x2odPrettierConfig = require('@x2od/prettier-config');
-
-module.exports = {
-	...x2odPrettierConfig,
-	semi: true
-};
-```
-
-### Configuration Considerations
-
-When extending, in the `js` configuration file, do not use an array for files. Prettier's override syntax requires a single string pattern (not arrays). Use curly braces for alternation:
-
-```json
-{
-	"files": "*.{yaml,yml}", // ['*.yaml','*.yml'] does not work
-	"options": {
-		"singleQuote": true
-	}
-}
-```
-
-To extend any section of the original file, refer to the original configuration and its attribute. This includes adding plugins. Be sure to include those additional plugins as local devDependencies.
-
-```javascript
-// prettier.config.js CommonJS
-/* eslint-disable no-undef */
+// prettier.config.js or .prettierrc.js
 const x2odPrettierConfig = require('@x2od/prettier-config');
 
 /**
@@ -132,7 +96,7 @@ const x2odPrettierConfig = require('@x2od/prettier-config');
  */
 module.exports = {
 	...x2odPrettierConfig,
-	tabWidth: 2,
+	printWidth: 100,
 	overrides: [
 		...x2odPrettierConfig.overrides,
 		{
@@ -147,16 +111,16 @@ module.exports = {
 };
 ```
 
-or to put the require line in the exports block. Note that arrays do not need to be extended if `require` is in teh exports block.
+You can also inline the `require()` call:
 
 ```javascript
+// prettier.config.js
 /**
  * @see https://prettier.io/docs/configuration
  * @type {import("prettier").Config}
  */
 module.exports = {
 	...require('@x2od/prettier-config'),
-	$schema: 'https://json.schemastore.org/prettierrc',
 	overrides: [
 		{
 			files: 'index.json',
@@ -175,7 +139,7 @@ module.exports = {
 };
 ```
 
-We can do the same for `.mjs` files
+**With ES modules (`.mjs`):**
 
 ```javascript
 // .prettierrc.mjs or prettier.config.mjs ESM
@@ -205,3 +169,20 @@ const config = {
 
 export default config;
 ```
+
+Note that additional plugins must be added as devDependencies in the project.
+
+## Configuration Considerations
+
+When adding overrides, use a single string pattern for `files` (not arrays). Use curly braces for alternation:
+
+```json
+{
+	"files": "*.{yaml,yml}",
+	"options": {
+		"singleQuote": true
+	}
+}
+```
+
+When extending sections like `overrides` and `plugins`, be sure to spread the original config's values (`...x2odPrettierConfig.overrides` and `...x2odPrettierConfig.plugins`) to preserve them. If adding plugins, install them as local devDependencies.


### PR DESCRIPTION
## Summary

Comprehensive documentation overhaul and configuration updates for improved clarity and maintainability.

## Changes

- **README.md**: Restructured and expanded documentation with:
  - Clearer installation instructions
  - Multiple configuration method examples (package.json, .prettierrc, .prettierrc.js, .prettierrc.mjs)
  - Complete default configuration reference with all settings and file-specific overrides
  - Improved extension examples for both CommonJS and ES modules
  - Better guidance on configuration considerations and override patterns
  - Added schema reference and improved code examples

- **Configuration**: Updated Prettier documentation URL to current version (en/configuration instead of en/configuration.html)

- **Build**: Updated .prettierignore to exclude LICENSE file from Prettier formatting

- **Copyright**: Updated LICENSE year to 2026

## Test Plan

- [x] README renders correctly on GitHub
- [x] All code examples are syntactically valid
- [x] Links in documentation are functional
- [ ] Configuration examples work when implemented

🤖 Generated with Claude Code