### PR TITLE
build(deps): remove self-referential @x2od/prettier-config devDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "prettier-plugin-pkg": "^0.22.1"
       },
       "devDependencies": {
-        "@x2od/prettier-config": "^0.0.8",
         "release-please": "^17.10.3"
       },
       "peerDependencies": {
@@ -424,27 +423,6 @@
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@x2od/prettier-config": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@x2od/prettier-config/-/prettier-config-0.0.8.tgz",
-      "integrity": "sha512-6GgQ36qOfjTLH4TugPGui1fM9cMcd5/Ua+4KrECLMQPA8Y7y41BW/WZsI8p2wDA6lh7nRs/c3fG3nIVKja5d7A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@prettier/plugin-xml": "^3.4.2",
-        "prettier-plugin-apex": "^2.3.0",
-        "prettier-plugin-organize-attributes": "^1.0.0",
-        "prettier-plugin-pkg": "^0.22.1"
-      },
-      "peerDependencies": {
-        "prettier": ">=3.1.0"
-      },
-      "peerDependenciesMeta": {
-        "prettier": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@xml-tools/parser": {
       "version": "1.0.11",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "prettier-plugin-pkg": "^0.22.1"
   },
   "devDependencies": {
-    "@x2od/prettier-config": "^0.0.8",
     "release-please": "^17.10.3"
   }
 }


### PR DESCRIPTION
## Summary

Removes the leftover self-referential `@x2od/prettier-config` devDependency.

The package listed **itself** as a devDependency — a holdover from when `.prettierrc.js` did `require('@x2od/prettier-config')`. Now that `.prettierrc.mjs` imports `./index.json` directly, nothing consumes it, so it's dead weight.

- `package.json` — drop the `@x2od/prettier-config` devDependency
- `package-lock.json` — prune the corresponding tree

No runtime or published-config impact; the package's `files` array only ships `index.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
