### PR TITLE
feat(config): format Apex and SOQL with spaces instead of tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ This config includes sensible defaults optimized for Salesforce development and 
 - `.{cmp,page,component}` — Salesforce Lightning components
 - `.{cls,trigger}` — Apex classes and triggers
 - `.{apex,soql}` — Apex anonymous and SOQL
-- `*.xml` — XML, with PMD rulesets and `*meta.xml` handled distinctly
+- `*.xml` — XML, with PMD rulesets and `*-meta.xml` handled distinctly
 - `.{yml,yaml}` — YAML files
 - `*.json` / `*.json5` — JSON files (printWidth: 80)
 - `package.json` — sorted via `prettier-plugin-pkg`

--- a/index.json
+++ b/index.json
@@ -47,7 +47,8 @@
     {
       "files": "*.{cls,trigger}",
       "options": {
-        "parser": "apex"
+        "parser": "apex",
+        "useTabs": false
       }
     },
     {
@@ -59,7 +60,8 @@
     {
       "files": "*.{apex,soql}",
       "options": {
-        "parser": "apex-anonymous"
+        "parser": "apex-anonymous",
+        "useTabs": false
       }
     },
     {

--- a/index.json
+++ b/index.json
@@ -73,7 +73,7 @@
       }
     },
     {
-      "files": "*meta.xml",
+      "files": "*-meta.xml",
       "options": {
         "parser": "xml",
         "useTabs": false,


### PR DESCRIPTION
## Summary

Two corrections to the per-file-type override matrix in `index.json`.

### Apex / SOQL indentation

Adds `useTabs: false` to the `*.{cls,trigger}` and `*.{apex,soql}` overrides so
Apex, triggers, anonymous Apex, and SOQL format with **spaces** instead of
inheriting the base `useTabs: true`.

### Salesforce metadata glob

Salesforce source-format metadata files end in `-meta.xml` (e.g.
`MyClass.cls-meta.xml`), not `.meta.xml`. Corrects the override glob from
`*meta.xml` to `*-meta.xml`, and updates the README's file-pattern list to match.

BEGIN_COMMIT_OVERRIDE
feat(config): format Apex and SOQL with spaces instead of tabs

BEGIN_NESTED_COMMIT
feat(config): match Salesforce metadata files with *-meta.xml glob
END_NESTED_COMMIT
END_COMMIT_OVERRIDE

🤖 Generated with [Claude Code](https://claude.com/claude-code)
