### PR TITLE
ci(renovate): require manual approval for major prettier updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,7 +13,8 @@
     },
     {
       "matchPackageNames": ["prettier"],
-      "matchUpdateTypes": ["major"]
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true
     }
   ],
   "major": {


### PR DESCRIPTION
## Summary

Adds `dependencyDashboardApproval: true` to the `prettier` major-update package rule in Renovate.

Major `prettier` bumps now require explicit approval from the dependency dashboard before Renovate opens a PR — a safeguard against a breaking Prettier major landing unreviewed, since this package declares Prettier as an optional peer dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
