### PR TITLE
chore(prettier): refine local package.json prettier local override

### DIFF
--- a/.prettierrc.mjs
+++ b/.prettierrc.mjs
@@ -10,10 +10,9 @@ const config = {
 	overrides: [
 		...x2odPrettierConfig.overrides,
 		{
-			files: 'index.json',
+			files: 'package.json',
 			options: {
-				singleQuote: false,
-				printWidth: 80
+				printWidth: 100
 			}
 		},
 		{


### PR DESCRIPTION
## Summary

Refines the repo-local Prettier overrides in `.prettierrc.mjs`. This file is **not** published — it only formats this repository — so the change has no effect on consumers of `@x2od/prettier-config`.

- Removes the redundant `index.json` override; its `printWidth: 80` / `singleQuote: false` are already applied by the shared `*.json` rule.
- Adds a `package.json` override at `printWidth: 100` so this repo's own manifest isn't wrapped at the narrower shared width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
