### PR TITLE
chore(release-please): remove unused deps changelog section

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -25,7 +25,6 @@
     { "type": "fix", "section": "Bug Fixes", "hidden": false },
     { "type": "test", "section": "Tests", "hidden": false },
     { "type": "chore", "section": "Miscellaneous Chores", "hidden": false },
-    { "type": "deps", "section": "Dependencies", "hidden": false },
     { "type": "perf", "section": "Performance Improvements", "hidden": false },
     { "type": "refactor", "section": "Code Refactoring", "hidden": false },
     { "type": "style", "section": "Styles", "hidden": false },


### PR DESCRIPTION
## Summary

Removes the dead `deps` changelog section from `release-please-config.json`.

No tooling emits `deps:` commits — Renovate is configured to use `build:` for dependency updates — so the `deps` section never populated. Dependency updates already surface under the `build` (and `ci`) sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
