### PR TITLE
docs(claude): add project memory files

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -1,0 +1,5 @@
+# Memory Index
+
+- [Commit & PR conventions](commit-conventions.md) — valid commit types, scopes, present-tense verbs, README updates, nested-commit blocks
+- [README is informational only](readme-informational-only.md) — don't flag README-vs-code drift as a bug
+- [package.json parser is required](package-json-parser-not-redundant.md) — json-stringify override must stay after `*.json` or plugin-pkg sorting breaks

--- a/.claude/memory/commit-conventions.md
+++ b/.claude/memory/commit-conventions.md
@@ -1,0 +1,41 @@
+---
+name: commit-conventions
+description: Directives for commit messages and pull requests in this repo
+metadata:
+  type: feedback
+---
+
+Commit and pull-request conventions the user requires in this repo
+(`@x2od/prettier-config`).
+
+**Commits:**
+- Always use a commit **type** that exists in the release-please configuration
+  (`release-please-config.json` → `changelog-sections`). Currently valid types:
+  `feat`, `fix`, `test`, `chore`, `perf`, `refactor`, `style`, `docs`, `revert`,
+  `ci`, `build`. Do not invent types (e.g. `deps`) that aren't listed.
+- Use a **scope** whenever appropriate, e.g. `feat(config):`,
+  `ci(release-please):`, `build(deps):`.
+- The commit **title must start with a present-tense verb** (e.g. "add",
+  "fix", "refine", "remove" — not "added"/"adds"/"adding").
+- **Any change to `index.json` is always a `feat`.** Every commit/PR that edits
+  `index.json` (the published Prettier config) MUST use the `feat` type,
+  regardless of the change's nature — even a bug fix, refactor, or formatting
+  tweak. `index.json` is what consumers install, so any edit is a
+  consumer-facing feature change. Scope it (e.g. `feat(config):`).
+
+**Pull requests:**
+- When opening OR updating a PR, update the README text to account for anything
+  new in the change. See [[readme-informational-only]] — the README is
+  informational, but it should still be refreshed when a PR introduces new
+  behavior worth documenting.
+- When working with a PR, if necessary use `BEGIN_NESTED_COMMIT` /
+  `END_NESTED_COMMIT` blocks (one pair per commit) in the PR description to add
+  additional commits to the release-please changelog.
+- **Do NOT hard-wrap paragraphs in PR descriptions.** Write each paragraph as a
+  single long line and let GitHub soft-wrap it; do not insert newlines mid-
+  paragraph. Keep blank lines between paragraphs, and keep list items / code
+  blocks as-is. (This applies to PR/issue descriptions, not to these memory
+  files.)
+
+**Why:** These match the repo's release-please + conventional-commit setup so
+the generated CHANGELOG stays clean and complete.

--- a/.claude/memory/package-json-parser-not-redundant.md
+++ b/.claude/memory/package-json-parser-not-redundant.md
@@ -1,0 +1,19 @@
+---
+name: package-json-parser-not-redundant
+description: The package.json override's json-stringify parser is required, not redundant
+metadata:
+  type: project
+---
+
+In `index.json`, the `package.json` override sets `"parser": "json-stringify"`.
+This looks redundant (Prettier already uses json-stringify for package.json by
+default) but it is NOT — it must come AFTER the earlier `*.json` override, which
+forces `"parser": "json"`. Without re-asserting json-stringify, that earlier
+override would win and disable `prettier-plugin-pkg`'s field sorting.
+
+**Why:** Prettier merges all matching overrides in array order; a later override
+wins on conflicting keys. Removing the explicit parser silently breaks
+package.json sorting.
+
+**How to apply:** Do not "clean up" this parser as redundant. Keep the
+`package.json` override positioned after the `*.json` override.

--- a/.claude/memory/readme-informational-only.md
+++ b/.claude/memory/readme-informational-only.md
@@ -1,0 +1,19 @@
+---
+name: readme-informational-only
+description: The README is informational only and does not need to match the actual config code
+metadata:
+  type: feedback
+---
+
+In this repo (`@x2od/prettier-config`), the README's examples and file-pattern
+descriptions do NOT have to stay in sync with the actual configuration in
+`index.json` / `.prettierrc.mjs`. The README is written as human-facing
+information for anyone reading the package, not as an authoritative spec.
+
+**Why:** The user stated this explicitly. Minor drift between documented globs
+(e.g. README says `*meta.xml`) and the real config (`*-meta.xml`) is acceptable
+and expected.
+
+**How to apply:** Do NOT flag README-vs-code mismatches as bugs or push to
+reconcile them. Treat the code as the source of truth; only update the README
+when the user asks.


### PR DESCRIPTION
## Summary

Adds Claude Code project memory files under `.claude/memory/`, capturing conventions and non-obvious decisions for this repo so future sessions have context.

- **commit-conventions** — valid commit types (must exist in the release-please config), scopes, present-tense verb titles, updating the README alongside PRs, nested-commit blocks, the rule that any `index.json` edit is a `feat`, and no hard-wrapping in PR descriptions.
- **readme-informational-only** — the README is informational and need not mirror the code exactly.
- **package-json-parser-not-redundant** — the `package.json` `json-stringify` parser override must stay after `*.json` or `prettier-plugin-pkg` sorting breaks.
- **MEMORY.md** — index of the above.

Documentation only; no effect on the published config or build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
