### PR TITLE
ci(release-please): serialize runs with a cancel-in-progress concurrency group

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,6 +9,13 @@ permissions:
   contents: write
   pull-requests: write
   id-token: write
+
+# Ensure only one release-please run happens at a time; a newer run cancels
+# any run already in progress for the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   release-please:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds a top-level `concurrency` group to the release-please workflow so its runs are serialized.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

With `cancel-in-progress: true`, when a newer run starts (e.g. rapid successive pushes to `main`), any run already in progress for the same ref is **cancelled** rather than running alongside it. This prevents two release-please runs from racing on the same branch.

Because the group is declared at the workflow level, cancellation covers the **entire** run, including the npm publish step — an in-progress publish is cancelled if a newer run is started.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
