### PR TITLE
chore(prettier): ignore package-lock.json and .claude

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 node_modules
 CHANGELOG.md
 LICENSE
+package-lock.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@ node_modules
 CHANGELOG.md
 LICENSE
 package-lock.json
+.claude


### PR DESCRIPTION
## Summary

Adds two entries to `.prettierignore` so Prettier stops formatting files it shouldn't touch.

- `package-lock.json` — machine-generated by npm; reformatting it produces churn and fights npm's own output on the next install.
- `.claude` — Claude Code project files (memory notes, settings) under `.claude/` aren't source we want Prettier to reformat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
