### PR TITLE
feat(config): add prettier-plugin-sh for shell script formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ This config includes sensible defaults optimized for Salesforce development and 
 - `.prettierrc*` — Prettier config files (printWidth: 80)
 - `*.md` — Markdown (spaces, not tabs)
 - `.html` — HTML files with custom attribute grouping (`doc*` and LWC templates)
+- `*.sh` — Shell scripts (spaces, `indent: 2`, via `prettier-plugin-sh`)
 
 **Plugins:**
 
@@ -73,6 +74,7 @@ This config includes sensible defaults optimized for Salesforce development and 
 - `@prettier/plugin-xml` — XML formatting
 - `prettier-plugin-organize-attributes` — HTML attribute organization
 - `prettier-plugin-pkg` — `package.json` field sorting
+- `prettier-plugin-sh` — Shell / Bash script formatting
 
 ## Extending Shared Configurations
 

--- a/index.json
+++ b/index.json
@@ -118,6 +118,14 @@
       }
     },
     {
+      "files": "package.json",
+      "options": {
+        "parser": "json-stringify",
+        "singleQuote": false,
+        "printWidth": 80
+      }
+    },
+    {
       "files": "doc*/**/*.html",
       "options": {
         "attributeGroups": ["$CODE_GUIDE"],
@@ -161,11 +169,14 @@
       "options": { "quoteProps": "consistent", "parser": "json5" }
     },
     {
-      "files": "package.json",
+      "files": "*.sh",
       "options": {
-        "parser": "json-stringify",
-        "singleQuote": false,
-        "printWidth": 80
+        "keepComments": true,
+        "useTabs": false,
+        "indent": 2,
+        "switchCaseIndent": true,
+        "spaceRedirects": true,
+        "functionNextLine": false
       }
     }
   ],
@@ -173,6 +184,7 @@
     "prettier-plugin-apex",
     "@prettier/plugin-xml",
     "prettier-plugin-organize-attributes",
-    "prettier-plugin-pkg"
+    "prettier-plugin-pkg",
+    "prettier-plugin-sh"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "prettier-plugin-pkg": "^0.22.1"
       },
       "devDependencies": {
+        "prettier-plugin-sh": "^0.19.0",
         "release-please": "^17.10.3"
       },
       "peerDependencies": {
@@ -389,6 +390,81 @@
       "peerDependencies": {
         "prettier": "^3.0.0"
       }
+    },
+    "node_modules/@reteps/dockerfmt": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@reteps/dockerfmt/-/dockerfmt-0.5.4.tgz",
+      "integrity": "sha512-HEGgXVVOb+JtGUSSzXl/XPKFIZjMDTUoHarCjaQdkY+cb5M9K/O3b5xm+x0IPIk3SfHurbc0bSgcFsQlzjitxA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "dockerfmt": "dist/launcher.js"
+      },
+      "engines": {
+        "node": "^v12.20.0 || ^14.13.0 || >=16.0.0"
+      },
+      "optionalDependencies": {
+        "@reteps/dockerfmt-darwin-arm64": "0.5.4",
+        "@reteps/dockerfmt-darwin-x64": "0.5.4",
+        "@reteps/dockerfmt-linux-arm64": "0.5.4",
+        "@reteps/dockerfmt-linux-x64": "0.5.4"
+      }
+    },
+    "node_modules/@reteps/dockerfmt-darwin-arm64": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@reteps/dockerfmt-darwin-arm64/-/dockerfmt-darwin-arm64-0.5.4.tgz",
+      "integrity": "sha512-urMqV+dQyvVI8/WrXwClX9e1PEyS35wFdwJjpZYmL09AkV4Io5U1oam8UBKK7jZk0+YsdF88ay6e86Kn6DIyQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@reteps/dockerfmt-darwin-x64": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@reteps/dockerfmt-darwin-x64/-/dockerfmt-darwin-x64-0.5.4.tgz",
+      "integrity": "sha512-fJORy6DFxbgDiMqxpLTPZlb5KUY0Vq0iR4NGnyKnuYZ9LdZUS508DK2kt/AJ87/jIKNV1qRG0JXG1Tc6xdvWjw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@reteps/dockerfmt-linux-arm64": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@reteps/dockerfmt-linux-arm64/-/dockerfmt-linux-arm64-0.5.4.tgz",
+      "integrity": "sha512-6pVakO06eXtDuvxy1Dnjs/gQyUoGGycle8PRSt5IFRwLi/AVaOQwfkfmW0WP8VH9wNUeti6BfJ3ksTn2G+XMxg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@reteps/dockerfmt-linux-x64": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@reteps/dockerfmt-linux-x64/-/dockerfmt-linux-x64-0.5.4.tgz",
+      "integrity": "sha512-OD6SIlUV1D4TgJoTui3FMBAZsGbTSPYsiT0BKhD6jMUcJb3GpFTa7dY9rL8rP9FUqfL7OTHVUGUOL4Rh64Olog==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -1919,6 +1995,26 @@
         "prettier": "^3.0.3"
       }
     },
+    "node_modules/prettier-plugin-sh": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-sh/-/prettier-plugin-sh-0.19.0.tgz",
+      "integrity": "sha512-39VXFZH/cOGtcuu8aeSvqp/hhwomOR4QroZUj+jBz2cNb3os9s0sqFZSNlYts6jdtLLDU7D2YT3Z1+abtb7adQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@reteps/dockerfmt": "^0.5.4",
+        "sh-syntax": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
+      },
+      "peerDependencies": {
+        "prettier": "^3.6.0"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
@@ -2173,6 +2269,19 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/sh-syntax": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/sh-syntax/-/sh-syntax-0.6.0.tgz",
+      "integrity": "sha512-52VK6z/cdZHv7UURjIcwfBUQZrAhIEEe0bY4lrkfypjnFIKsDZdD3Uaz/dBiw/sF8BeX0Mssv140s8EnrsJ9dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/sh-syntax"
       }
     },
     "node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "@prettier/plugin-xml": "^3.4.2",
     "prettier-plugin-apex": "^2.3.0",
     "prettier-plugin-organize-attributes": "^1.0.0",
-    "prettier-plugin-pkg": "^0.22.1"
+    "prettier-plugin-pkg": "^0.22.1",
+    "prettier-plugin-sh": "^0.19.0"
   },
   "devDependencies": {
     "release-please": "^17.10.3"


### PR DESCRIPTION
## Summary

Adds shell-script support to the shared config via `prettier-plugin-sh`.

- Registers `prettier-plugin-sh` in the `plugins` array and adds it as a runtime `dependency` (alongside the other bundled plugins), so consumers get it automatically.
- Adds a `*.sh` override formatting shell scripts with 2-space indentation (`useTabs: false`, `indent: 2` stated explicitly so the intent is clear), spaced redirects, and indented switch cases.
- Documents the new plugin and `*.sh` file pattern in the README lists.

The `package.json` override was moved up so it still sits immediately after the `*.json` override — that ordering is required so its `json-stringify` parser wins and `prettier-plugin-pkg` sorting keeps working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
