### PR TITLE
ci(husky): add pre-commit prettier hook and commit-msg linter

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,0 +1,35 @@
+name: prettier
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# One formatting check per ref is enough; a newer push cancels any run already
+# in progress for the same branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 'lts/*'
+          cache: 'npm'
+      - name: Install Dependencies
+        run: npm ci
+      # Backstop for the pre-commit hook: catches anything committed with
+      # --no-verify, edited through the GitHub web UI, or merged without the
+      # hook having run. Prints the offending files and exits non-zero.
+      - name: Verify formatting
+        run: npm run prettier:verify

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,1 @@
+node scripts/lint-commit-msg.js "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,7 @@
+# Keep generated docs in sync (no-op until you configure targets in the script).
+[ -f scripts/update-docs.js ] && node scripts/update-docs.js
+
+# Format only the files being committed (Prettier via lint-staged, which
+# re-stages them). A formatting failure blocks the commit on purpose. The guard
+# just skips gracefully in a no-npm / plain-.git/hooks install.
+[ -f node_modules/.bin/lint-staged ] && npm run lint-staged

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ CHANGELOG.md
 LICENSE
 package-lock.json
 .claude
+.husky/_

--- a/git-automation.config.json
+++ b/git-automation.config.json
@@ -1,0 +1,16 @@
+{
+  "repoUrl": null,
+  "commitTypes": [
+    "feat",
+    "fix",
+    "test",
+    "chore",
+    "perf",
+    "refactor",
+    "style",
+    "docs",
+    "revert",
+    "ci",
+    "build"
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,8 @@
         "prettier-plugin-sh": "^0.19.0"
       },
       "devDependencies": {
+        "husky": "^9.1.7",
+        "lint-staged": "^17.1.0",
         "prettier": "^3.9.5",
         "release-please": "^17.10.3"
       },
@@ -1408,6 +1410,22 @@
         "node": ">= 6"
       }
     },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    },
     "node_modules/indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -1590,6 +1608,30 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lint-staged": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.1.0.tgz",
+      "integrity": "sha512-d7UQRu/9ZPgfu4+hu/k0wny5GEaIxo+2jb2LJqQDkE7cHRTm1HGqNUDq5UOwsGPpjpaNAFmgAsYo3TR+i9cSJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^4.0.5",
+        "string-argv": "^0.3.2",
+        "tinyexec": "^1.2.4"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=22.22.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      },
+      "optionalDependencies": {
+        "yaml": "^2.9.0"
+      }
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
@@ -1923,6 +1965,19 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/prettier": {
       "version": "3.9.5",
@@ -2336,6 +2391,16 @@
         "node": "*"
       }
     },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -2409,6 +2474,16 @@
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/trim-newlines": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,10 @@
   ],
   "scripts": {
     "changelog:preview": "release-please release-pr --repo-url=x2od/prettier-config --target-branch=$(git branch --show-current) --dry-run --token=$(gh auth token)",
+    "lint-staged": "lint-staged",
     "minor": "npm version minor",
     "patch": "npm version patch",
+    "prepare": "husky",
     "prettier": "prettier --write .",
     "prettier:verify": "prettier --list-different .",
     "renovate:validate": "npm install renovate && npx renovate-config-validator && npm uninstall renovate"
@@ -45,7 +47,12 @@
     "prettier-plugin-sh": "^0.19.0"
   },
   "devDependencies": {
+    "husky": "^9.1.7",
+    "lint-staged": "^17.1.0",
     "prettier": "^3.9.5",
     "release-please": "^17.10.3"
+  },
+  "lint-staged": {
+    "*": "prettier --write --ignore-unknown"
   }
 }

--- a/scripts/lib/automation-config.js
+++ b/scripts/lib/automation-config.js
@@ -1,0 +1,87 @@
+'use strict';
+/**
+ * automation-config.js
+ *
+ * Shared config loader for the git-automation scripts. Reads an optional
+ * `git-automation.config.json` from the repo root and fills in sensible
+ * defaults so every project can run with zero or minimal configuration.
+ *
+ * The one value worth auto-detecting is the repo URL — we derive it from
+ * `git remote get-url origin` so a fresh project needs no config at all to
+ * get clickable commit/PR links in its changelog.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+// Walk up from CWD to find the repo root (the dir containing `.git`). Scripts
+// are normally run from the root, but hooks/CI may invoke from elsewhere.
+function findRepoRoot(start) {
+	let dir = start;
+	while (dir !== path.dirname(dir)) {
+		if (fs.existsSync(path.join(dir, '.git'))) return dir;
+		dir = path.dirname(dir);
+	}
+	return start;
+}
+
+const ROOT = findRepoRoot(process.cwd());
+
+const DEFAULTS = {
+	// null → auto-detect from the git remote at load time.
+	repoUrl: null,
+	changelog: {
+		output: 'CHANGELOG.md',
+		// Optional path (relative to root) to a markdown file appended verbatim
+		// as a permanent footer — e.g. pre-reset history. null = no footer.
+		historyFooterFile: null
+	},
+	// Allowed semantic commit types (commit-lint) and their changelog emoji.
+	commitTypes: ['feat', 'fix', 'docs', 'style', 'refactor', 'perf', 'test', 'build', 'ci', 'chore', 'revert', 'deps'],
+	// Commits by these authors are treated as automated noise and skipped.
+	botAuthors: ['github-actions[bot]', 'github-actions']
+};
+
+function loadRaw() {
+	const p = path.join(ROOT, 'git-automation.config.json');
+	if (!fs.existsSync(p)) return {};
+	try {
+		return JSON.parse(fs.readFileSync(p, 'utf8'));
+	} catch (e) {
+		console.warn(`⚠️  git-automation.config.json is invalid JSON — using defaults (${e.message})`);
+		return {};
+	}
+}
+
+function detectRepoUrl() {
+	try {
+		const remote = execSync('git remote get-url origin', {
+			cwd: ROOT,
+			encoding: 'utf8',
+			stdio: ['pipe', 'pipe', 'pipe'] // capture stderr so "no remote" stays quiet
+		}).trim();
+		// SSH form:   git@github.com:user/repo.git
+		const ssh = remote.match(/^git@([^:]+):(.+?)(?:\.git)?$/);
+		if (ssh) return `https://${ssh[1]}/${ssh[2]}`;
+		// HTTPS form: https://[token@]github.com/user/repo.git
+		const https = remote.match(/^https?:\/\/(?:[^@]+@)?(.+?)(?:\.git)?$/);
+		if (https) return `https://${https[1]}`;
+		return null;
+	} catch {
+		return null; // no remote, or git unavailable — links degrade gracefully
+	}
+}
+
+function loadConfig() {
+	const raw = loadRaw();
+	const cfg = {
+		...DEFAULTS,
+		...raw,
+		changelog: { ...DEFAULTS.changelog, ...(raw.changelog || {}) }
+	};
+	if (!cfg.repoUrl) cfg.repoUrl = detectRepoUrl();
+	return cfg;
+}
+
+module.exports = { ROOT, loadConfig, detectRepoUrl };

--- a/scripts/lint-commit-msg.js
+++ b/scripts/lint-commit-msg.js
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+/**
+ * lint-commit-msg.js
+ *
+ * Validates the commit message against the project's semantic commit
+ * convention. Called by the Husky commit-msg hook with the path to the
+ * commit message file.
+ *
+ * Convention:  <type>(<scope>)?<!>?: <description>
+ * Valid types come from git-automation.config.json (commitTypes), defaulting
+ * to: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert, deps
+ *
+ * A trailing `!` on the type/scope marks a breaking change and REQUIRES a
+ * `BREAKING CHANGE: ` footer paragraph in the body (that text heads the
+ * changelog). Release-please control markers (`BEGIN_…`/`END_…`) must be
+ * balanced — an unmatched one silently mangles the changelog.
+ *
+ * Exits 1 (blocks the commit) if the format is wrong, a breaking change lacks
+ * its footer, or a control marker is unbalanced.
+ * Prints a warning but exits 0 for minor issues (short/generic description,
+ * control markers present in a commit message).
+ */
+
+const fs = require('fs');
+const { loadConfig } = require('./lib/automation-config');
+
+const { commitTypes } = loadConfig();
+
+const msgFile = process.argv[2];
+if (!msgFile) {
+	console.error('lint-commit-msg: no message file path provided');
+	process.exit(0); // non-fatal
+}
+
+const msg = fs.readFileSync(msgFile, 'utf8').trim();
+
+// Ignore merge commits, reverts, fixups, and WIP — these aren't authored prose.
+if (/^(Merge|Revert|fixup!|squash!|WIP)/i.test(msg)) {
+	process.exit(0);
+}
+
+const TYPE_LIST = commitTypes.join('|');
+
+// Full format:  type(scope)!: description  — scope and the breaking-change `!`
+// are both optional:  type: description  /  type(scope): description  /  type!: …
+const VALID = new RegExp(`^(${TYPE_LIST})(\\([^)]+\\))?(!)?: .{4,}`, 'i');
+
+const firstLine = msg.split('\n')[0];
+
+if (!VALID.test(firstLine)) {
+	const typesPretty = commitTypes.join(' · ');
+	console.error(`
+✗  Commit message doesn't follow the project convention
+
+   Expected:  <type>(<scope>): <description>
+   Example:   feat(auth): add JWT-based login
+   Breaking:  feat(auth)!: drop legacy tokens   (needs a BREAKING CHANGE: footer)
+
+   Valid types: ${typesPretty}
+
+   Your message:
+   ${firstLine}
+`);
+	process.exit(1);
+}
+
+// ── Breaking change (`!`) requires a BREAKING CHANGE: footer ───────────────────
+// A `!` after the type/scope declares a breaking change; the convention requires
+// exactly one `BREAKING CHANGE: ` paragraph in the body — that text is what heads
+// the changelog. Block the commit if it's missing so the signal never gets lost.
+const isBreaking = new RegExp(`^(${TYPE_LIST})(\\([^)]+\\))?!:`, 'i').test(firstLine);
+const hasBreakingFooter = /^BREAKING CHANGE: .+/m.test(msg);
+if (isBreaking && !hasBreakingFooter) {
+	console.error(`
+✗  Breaking change (\`!\`) is missing its BREAKING CHANGE: footer
+
+   A \`!\` after the type/scope marks a breaking change, so the message must
+   include exactly one paragraph in the body that starts with:
+
+       BREAKING CHANGE: <what breaks, and what consumers must do>
+
+   That paragraph is what surfaces at the top of the changelog. Add it, or drop
+   the \`!\` if the change isn't actually breaking.
+
+   Your subject:
+   ${firstLine}
+`);
+	process.exit(1);
+}
+
+// ── Release-please control markers must be balanced ────────────────────────────
+// Every BEGIN_<NAME> must have a matching END_<NAME> (and vice versa). Release-
+// please parses these anywhere in the text, so an unmatched one silently drops or
+// mangles a changelog entry. Match generically so any current or future marker
+// pair is covered, not just the two documented ones.
+const beginNames = [...msg.matchAll(/\bBEGIN_([A-Z][A-Z0-9_]*)\b/g)].map((m) => m[1]);
+const endNames = [...msg.matchAll(/\bEND_([A-Z][A-Z0-9_]*)\b/g)].map((m) => m[1]);
+const markerNames = new Set([...beginNames, ...endNames]);
+const unbalanced = [];
+for (const name of markerNames) {
+	const opens = beginNames.filter((n) => n === name).length;
+	const closes = endNames.filter((n) => n === name).length;
+	if (opens !== closes) unbalanced.push(`   • ${name}: ${opens} BEGIN_ vs ${closes} END_`);
+}
+if (unbalanced.length) {
+	console.error(`
+✗  Unbalanced release-please control marker(s)
+
+   Each BEGIN_<NAME> block must be closed by a matching END_<NAME>. Release-please
+   reads these markers literally and will silently drop or mangle a changelog
+   entry when one is left open:
+
+${unbalanced.join('\n')}
+
+   Close the block, or remove the marker if you didn't mean to use one.
+`);
+	process.exit(1);
+}
+
+// Soft warnings (don't block)
+
+// Control markers are powerful and are parsed anywhere in the text — flag their
+// presence in a commit message (they normally live in PR descriptions) so an
+// accidental mention doesn't quietly steer release-please.
+if (markerNames.size) {
+	console.warn('⚠️  commit-msg: release-please control markers present (BEGIN_…/END_…) — make sure that use is intentional');
+}
+
+const description = firstLine.replace(/^[^:]+:\s*/, '');
+if (description.length < 10) {
+	console.warn('⚠️  commit-msg: description is very short — consider being more specific');
+}
+if (/^(update|fix|change|add|remove)$/i.test(description)) {
+	console.warn('⚠️  commit-msg: description is too generic — say what was updated/fixed/changed');
+}
+
+process.exit(0);


### PR DESCRIPTION
## What

Formatting is now enforced at commit time by a Husky pre-commit hook, with a CI workflow as the backstop. Commit messages are linted against the repo's conventional-commit types. Scaffolded with the `git-automation` skill, minus its changelog half — release-please already owns that.

| Piece | Behavior |
| --- | --- |
| `.husky/pre-commit` | lint-staged runs `prettier --write --ignore-unknown` over staged files and re-stages them |
| `.husky/commit-msg` | rejects messages that don't match `type(scope): description` |
| `.github/workflows/prettier.yml` | runs `npm run prettier:verify` on pull requests and pushes to `main` |

## Why

#71 made `prettier` a real devDependency, which is what these two need to be worth anything — a hook and a CI check are only meaningful against a pinned formatter version.

The hook is the actual fix: unformatted code can't land through a normal commit, because lint-staged formats and re-stages before the commit is written. The workflow is the backstop, not a duplicate — it catches what the hook structurally cannot: commits made with `--no-verify`, edits through the GitHub web UI, and clones where `npm install` was never run so `.husky/` isn't wired up.

This is the class of drift that started the thread: `.prettierignore` sat unformatted because nothing ran Prettier over it after `prettier-plugin-sh` landed in #70.

## Two decisions worth noting

**The lint-staged glob is `*`, not an extension list.** The skill's default (`*.{js,ts,json,html,css,md,yml,yaml}`) is wrong for this repo — the plugin set covers XML, Apex and shell, and `plugin-sh` also claims extensionless dotfiles like `.prettierignore` and `.gitignore`. An extension list would have silently skipped the exact file that prompted this work. `--ignore-unknown` makes the broad glob safe by skipping anything Prettier has no parser for.

**`commitTypes` is pinned to release-please's list.** The scaffolding's default set additionally includes `deps`, which this repo doesn't use. Left as-is, a `deps(...)` commit would lint clean and then silently produce no changelog entry, since `deps` isn't in `release-please-config.json`'s `changelog-sections`. The config now mirrors those eleven types exactly.

Note the coupling this creates: adding a type to `release-please-config.json` means adding it to `git-automation.config.json` too, or the linter will reject commits the changelog would happily accept.

## Also included

`.husky/_` is added to `.prettierignore` — Prettier was reformatting Husky's vendored runtime shim, which `husky init` regenerates anyway.

No `post-commit` hook and no `generate-changelog.js`: release-please owns the changelog, and the skill's local-changelog mechanism is mutually exclusive with it.

## Verification

Each behavior was exercised directly rather than assumed:

| Case | Expected | Result |
| --- | --- | --- |
| `this message has no type` | blocked | exit 1, lists the eleven valid types |
| `ci(husky): …` | accepted | exit 0 |
| `deps(x): bump something` | blocked here | exit 1 |
| `feat(x)!: …` without footer | blocked | exit 1 |
| `feat(x)!: …` with `BREAKING CHANGE:` | accepted | exit 0 |
| staged `{"z":1,   "a":  2}` | reformatted + re-staged | committed as `{ "z": 1, "a": 2 }` |

Both commits in this PR went through the hooks themselves. `prettier --list-different .` exits `0` on the branch.

The workflow is the one piece that can't be verified locally — this PR is its first real run, since it triggers on `pull_request`.

Nothing consumer-facing changed: `index.json` is untouched, so the published config is byte-identical and the README needed no update.

BEGIN_NESTED_COMMIT
ci(prettier): add workflow verifying formatting on pull requests

Runs `npm run prettier:verify` on pull requests and pushes to `main`, catching anything the pre-commit hook couldn't — `--no-verify` commits, web-UI edits, and clones without `npm install`.
END_NESTED_COMMIT

🤖 Generated with [Claude Code](https://claude.com/claude-code)
