### PR TITLE
chore(release-please): add emoji to changelog section headers

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -21,16 +21,20 @@
     }
   ],
   "changelog-sections": [
-    { "type": "feat", "section": "Features", "hidden": false },
-    { "type": "fix", "section": "Bug Fixes", "hidden": false },
-    { "type": "test", "section": "Tests", "hidden": false },
-    { "type": "chore", "section": "Miscellaneous Chores", "hidden": false },
-    { "type": "perf", "section": "Performance Improvements", "hidden": false },
-    { "type": "refactor", "section": "Code Refactoring", "hidden": false },
-    { "type": "style", "section": "Styles", "hidden": false },
-    { "type": "docs", "section": "Documentation", "hidden": false },
-    { "type": "revert", "section": "Reverts", "hidden": false },
-    { "type": "ci", "section": "Continuous Integration", "hidden": false },
-    { "type": "build", "section": "Build System", "hidden": false }
+    { "type": "feat", "section": "✨ Features", "hidden": false },
+    { "type": "fix", "section": "🐛 Bug Fixes", "hidden": false },
+    { "type": "test", "section": "✅ Tests", "hidden": false },
+    { "type": "chore", "section": "🔧 Miscellaneous Chores", "hidden": false },
+    {
+      "type": "perf",
+      "section": "⚡ Performance Improvements",
+      "hidden": false
+    },
+    { "type": "refactor", "section": "♻️ Code Refactoring", "hidden": false },
+    { "type": "style", "section": "🎨 Styles", "hidden": false },
+    { "type": "docs", "section": "📝 Documentation", "hidden": false },
+    { "type": "revert", "section": "⏪ Reverts", "hidden": false },
+    { "type": "ci", "section": "👷 Continuous Integration", "hidden": false },
+    { "type": "build", "section": "📦 Build System", "hidden": false }
   ]
 }


### PR DESCRIPTION
## What

Adds an emoji to each of the eleven `changelog-sections` headers in `release-please-config.json`, so generated changelog sections match the styling used in the other x2od repos.

| Type | Section | Type | Section |
| --- | --- | --- | --- |
| `feat` | ✨ Features | `docs` | 📝 Documentation |
| `fix` | 🐛 Bug Fixes | `style` | 🎨 Styles |
| `test` | ✅ Tests | `refactor` | ♻️ Code Refactoring |
| `chore` | 🔧 Miscellaneous Chores | `revert` | ⏪ Reverts |
| `perf` | ⚡ Performance Improvements | `ci` | 👷 Continuous Integration |
| `build` | 📦 Build System | | |

## Where these came from

Eight are lifted verbatim from the emoji map already in use by the changelog generator shared across these repos (`scripts/generate-changelog.js`): `feat ✨`, `fix 🐛`, `docs 📝`, `style 🎨`, `refactor ♻️`, `test ✅`, `chore 🔧`, `ci 👷`. Reusing them keeps this repo's changelog visually consistent with the others rather than introducing a second palette.

That map doesn't cover `perf`, `revert`, or `build`, so those three are new picks following the same gitmoji conventions: ⚡, ⏪, and 📦. 📦 is the generator's own fallback for unmapped types, so it's the value those repos would already render for `build`.

## Scope

Section headers only — no type was added, removed, or hidden, and no versioning behavior changes. Existing `CHANGELOG.md` entries keep their current plain headings; release-please applies section names only to newly generated entries, so the emoji show up from the next release onward.

## Verification

The config parses, all eleven sections carry an emoji, and `prettier --list-different .` exits `0`.

Not verified: how the headings actually render in a generated changelog. `npm run changelog:preview` needs the GitHub API, which was mid-outage when this was written, and it targets the current branch rather than a release. The first real release-please run is what will confirm it.

One cosmetic side effect worth a glance: the added emoji pushed the `perf` entry past `printWidth`, so Prettier expanded it across four lines while its neighbours stay on one. That's the formatter's own output, left as-is.

Nothing consumer-facing changed — `index.json` is untouched, so the published config is byte-identical and the README needed no update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
